### PR TITLE
#710 rollback drop support for proprietary_codecs

### DIFF
--- a/build/cromite.gn_args
+++ b/build/cromite.gn_args
@@ -37,11 +37,13 @@ enable_feed_v2=false
 enable_cardboard=false
 is_high_end_android=true
 
-# Do not compile with proprietary codecs
-proprietary_codecs=false
-ffmpeg_branding="Chromium"
+proprietary_codecs=true
+ffmpeg_branding="Chrome"
 enable_av1_decoder=true
 enable_dav1d_decoder=true
+enable_platform_dolby_vision=true
+enable_platform_hevc=true
+enable_mse_mpeg2ts_stream_parser=true
 
 # Do not compile libmonochrome.so with RELR relocations
 # since supported only on API 28+


### PR DESCRIPTION
## Description

*Please explain here what feature or bugfix these changes are addressing and why they should be included*

## All submissions

* [ ] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [ ] Bromite can be built with these changes
* [ ] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [ ] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [ ] patch description contains explanation of changes
* [ ] no unnecessary whitespace or unrelated changes
